### PR TITLE
fix: Remove the entrypoint script and just execute directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
 FROM ghcr.io/underdog-tech/vulnbot:v0.4.1
 
-COPY entrypoint.sh /entrypoint.sh
-
-RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+CMD [ "/vulnbot" "scan" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e
-
-sh -c "/app/vulnbot scan $*"


### PR DESCRIPTION
I built up a local test loosely derived from an actual GitHub Action run.

```console
❯ docker build . -t vulnbot-action
[+] Building 1.0s (6/6) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                                                                                             0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 106B                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for ghcr.io/underdog-tech/vulnbot:v0.4.1                                                                                                                                                                                       0.9s
 => [auth] underdog-tech/vulnbot:pull token for ghcr.io                                                                                                                                                                                                     0.0s
 => CACHED [1/1] FROM ghcr.io/underdog-tech/vulnbot:v0.4.1@sha256:89e6eabd5d4a7bf952010764ea7f06f5dcc9ce983adb5f7a1b2a594ebebe5e2d                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                                                      0.1s
 => => exporting layers                                                                                                                                                                                                                                     0.0s
 => => writing image sha256:42c696e0171bf573edce6dee9236d3e1c4bd262a3f1c74c82c26ff9f8ed588d5                                                                                                                                                                0.1s
 => => naming to docker.io/library/vulnbot-action                                                                                                                                                                                                           0.0s
❯ docker run --rm -v .:/github/home --workdir /github/home vulnbot-action  "scan" "-d" "--config=vulnbot.toml"
2023-06-30T14:44:46Z INF Querying GitHub API for vulnerable repositories. go_version=go1.20.5
2023-06-30T14:44:50Z INF Querying GitHub API for vulnerable repositories. go_version=go1.20.5
2023-06-30T14:44:52Z INF Querying GitHub API for repository ownership information. go_version=go1.20.5
2023-06-30T14:44:54Z INF Collating results. go_version=go1.20.5
...
2023-06-30T14:44:54Z INF Done! go_version=go1.20.5
❯ 
```