### PR TITLE
Bump vulnbot-action to v0.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/underdog-tech/vulnbot:v0.4.1
+FROM ghcr.io/underdog-tech/vulnbot:v0.5.0
 
 ENTRYPOINT [ "/vulnbot" ]
 CMD [ "scan" ]


### PR DESCRIPTION
## This Change

Please visit the following release page for more details: https://github.com/underdog-tech/vulnbot/releases/tag/v0.5.0.